### PR TITLE
Add namePrependSlash property to ZipOptions interface in archiver

### DIFF
--- a/types/archiver/archiver-tests.ts
+++ b/types/archiver/archiver-tests.ts
@@ -14,6 +14,7 @@ const options: Archiver.ArchiverOptions = {
     comment: 'test',
     forceLocalTime: true,
     forceZip64: true,
+    namePrependSlash: true,
     store: true,
     zlib: {},
     gzip: true,

--- a/types/archiver/index.d.ts
+++ b/types/archiver/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for archiver 5.1
+// Type definitions for archiver 5.3
 // Project: https://github.com/archiverjs/node-archiver
 // Definitions by:  Esri
 //                  Dolan Miu <https://github.com/dolanmiu>

--- a/types/archiver/index.d.ts
+++ b/types/archiver/index.d.ts
@@ -125,6 +125,7 @@ declare namespace archiver {
         comment?: string;
         forceLocalTime?: boolean;
         forceZip64?: boolean;
+        namePrependSlash?: boolean;
         store?: boolean;
         zlib?: ZlibOptions;
     }


### PR DESCRIPTION
This pull request adds support for the namePrependSlash property of the ZipOptions interface which was added in v5.3.0 of archiver.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.archiverjs.com/docs/archiver
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
